### PR TITLE
Fix Navbar component to hide mobile nav menu when path changes

### DIFF
--- a/src/client/components/routing/Navbar.tsx
+++ b/src/client/components/routing/Navbar.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BiUser } from 'react-icons/bi';
 import { RiMenuLine, RiCloseLine } from 'react-icons/ri';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 
 import { ReactComponent as Logo } from '../../assets/logo-noBg.svg';
 import { useAuth } from '../../contexts/AuthContext';
@@ -11,7 +11,10 @@ import styles from './Navbar.module.scss';
 
 export default function Navbar() {
   const { authed } = useAuth();
+  const { pathname } = useLocation();
   const [showNav, setShowNav] = useState(false);
+
+  useEffect(() => setShowNav(false), [pathname]);
 
   const toggleNav = () => setShowNav((prevShowNav) => !prevShowNav);
 


### PR DESCRIPTION
# Description
Use useLocation and useEffect hooks to hide the mobile nav menu when the path changes. The menu now collapses when the user clicks a nav link that takes them to a route other than their current route.