### PR TITLE
Add minYThrottle parameter to useScrollListener

### DIFF
--- a/src/client/components/routing/Navbar.tsx
+++ b/src/client/components/routing/Navbar.tsx
@@ -16,7 +16,7 @@ export default function Navbar(): JSX.Element {
   const [showNav, setShowNav] = useState<boolean>(false);
   const [navbarHidden, setNavbarHidden] = useState<boolean>(false);
 
-  const scroll = useScrollListener();
+  const scroll = useScrollListener(150);
 
   useEffect(() => {
     if (scroll.y > 150 && scroll.y - scroll.prevY > 0) setNavbarHidden(true);

--- a/src/client/helpers/useScrollListener.ts
+++ b/src/client/helpers/useScrollListener.ts
@@ -2,13 +2,15 @@ import { useEffect, useState } from 'react';
 
 /**
  * A React hook that listens to scroll events and returns scroll data.
+ * @param minYThrottle The minimum vertical scroll position starting at which the scroll event handler will be throttled (delay of 100ms).
+ * If omitted, the handler will be throttled at all scroll positions.
  * @returns scrollData Object containing scroll position data.
  * @returns scrollData.x Current horizontal scroll position.
  * @returns scrollData.y Current vertical scroll position.
  * @returns scrollData.prevX Previous horizontal scroll position.
  * @returns scrollData.prevY Previous vertical scroll position.
  */
-export default function useScrollListener() {
+export default function useScrollListener(minYThrottle = 0) {
   const [scrollData, setScrollData] = useState({ x: 0, y: 0, prevX: 0, prevY: 0 });
 
   useEffect(() => {
@@ -26,7 +28,7 @@ export default function useScrollListener() {
       let wait = false;
 
       return () => {
-        if (wait) return;
+        if (wait && window.scrollY >= minYThrottle) return;
 
         handleScroll();
         wait = true;


### PR DESCRIPTION
# Description
Added a minYThrottle parameter to useScrollListener hook in order to prevent bug where nav is hidden despite user being at the top of the page if they scroll down and then up very suddenly.
