### PR TITLE
Use top navbar only instead of expandable mobile menu when user unauthed

### DIFF
--- a/src/client/components/routing/Navbar.module.scss
+++ b/src/client/components/routing/Navbar.module.scss
@@ -57,21 +57,25 @@
     height: 100%;
     flex-grow: 1;
 
-    @media (max-width: var.$breakpoint-md) {
-      position: absolute;
-      flex-direction: column;
-      justify-content: space-around;
-      transition: height 0.4s ease;
-      width: 100vw;
-      height: calc(100vh - 4rem);
-      top: 4rem;
+    &--collapsible {
+      @media (max-width: var.$breakpoint-md) {
+        position: absolute;
+        flex-direction: column;
+        justify-content: space-around;
+        transition: height 0.4s ease;
+        width: 100vw;
+        height: calc(100vh - 4rem);
+        top: 4rem;
 
-      @include themes.themed {
-        background-color: themes.t('bg-nav-mobile');
+        @include themes.themed {
+          background-color: themes.t('bg-nav-mobile');
+        }
       }
+    }
 
-      // Screen reader only
-      &--collapsed:not(:focus-within):not(:focus):not(:active) {
+    // Screen reader only
+    &--collapsed:not(:focus-within):not(:focus):not(:active) {
+      @media (max-width: var.$breakpoint-md) {
         @include containers.visually-hidden;
       }
     }
@@ -86,38 +90,44 @@
     margin: 0;
     padding: 0;
 
-    @media (max-width: var.$breakpoint-md) {
-      width: 100%;
-      height: auto;
+    &--collapsible {
+      @media (max-width: var.$breakpoint-md) {
+        width: 100%;
+        height: auto;
+      }
     }
 
-    &--left {
+    &--left, &--left-collapsible {
       flex-grow: 1;
+    }
 
+    &--left-collapsible {
       @media (max-width: var.$breakpoint-md) {
         flex-direction: column;
         justify-content: space-around;
-        width: 100%;
       }
     }
 
-    &--left li {
+    &--left li, &--left-collapsible li {
       height: 100%;
+    }
 
+    &--left-collapsible li {
       @media (max-width: var.$breakpoint-md) {
         width: 100%;
       }
     }
 
-    &--right {
+    &--right, &--right-collapsible {
       padding-right: 0.75rem;
       gap: 1rem;
       justify-content: flex-end;
+    }
 
+    &--right-collapsible {
       @media (max-width: var.$breakpoint-md) {
         padding-right: 0;
         gap: 3rem;
-        height: auto;
         flex-grow: 0.5;
         justify-content: center;
       }

--- a/src/client/components/routing/Navbar.test.tsx
+++ b/src/client/components/routing/Navbar.test.tsx
@@ -63,20 +63,6 @@ describe('Navbar', () => {
     expect(screen.getByRole('button', { name: /activate (dark|light) mode/i })).toBeInTheDocument();
   });
 
-  it('shows home and login links and theme toggle button when user is not logged in', () => {
-    authed = false;
-    render(<RouterProvider router={router} />);
-    expect(screen.getByText('Home')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Login' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /activate (dark|light) mode/i })).toBeInTheDocument();
-  });
-
-  it('does not show login link when user is logged in', () => {
-    authed = true;
-    render(<RouterProvider router={router} />);
-    expect(screen.queryByText('Login')).not.toBeInTheDocument();
-  });
-
   it('does not show decks, study, stats, or profile links when user is not logged in', () => {
     authed = false;
     render(<RouterProvider router={router} />);
@@ -124,14 +110,6 @@ describe('Navbar', () => {
     const link = screen.getByRole('link', { name: 'Profile' });
     await userEvent.click(link);
     expect(router.state.location.pathname).toEqual('/profile');
-  });
-
-  it('navigates to "/login" when the login link is clicked', async () => {
-    authed = false;
-    render(<RouterProvider router={router} />);
-    const link = screen.getByRole('link', { name: 'Login' });
-    await userEvent.click(link);
-    expect(router.state.location.pathname).toEqual('/login');
   });
 
   it('toggles aria-label when mobile menu toggle button is clicked', async () => {

--- a/src/client/components/routing/Navbar.tsx
+++ b/src/client/components/routing/Navbar.tsx
@@ -13,26 +13,30 @@ import styles from './Navbar.module.scss';
 export default function Navbar(): JSX.Element {
   const { authed, userInfo } = useAuth();
   const { pathname } = useLocation();
-  const [showNav, setShowNav] = useState<boolean>(false);
+  // menuExpanded indicates whether the mobile nav menu is expanded (true) or collapsed (false).
+  const [menuExpanded, setMenuExpanded] = useState<boolean>(false);
+  // navbarHidden indicates whether the top navbar is hidden because the user has scrolled down.
   const [navbarHidden, setNavbarHidden] = useState<boolean>(false);
+  // showPicture indicates whether the user's profile picture (true) or the default
+  // profile picture (false) should be used.
   const [showPicture, setShowPicture] = useState<boolean>(true);
 
   const scroll = useScrollListener(150);
 
   useEffect(() => {
-    if (scroll.y > 150 && scroll.y - scroll.prevY > 0) setNavbarHidden(true);
+    if (scroll.y > 150 && scroll.y - scroll.prevY > 0 && authed) setNavbarHidden(true);
     else setNavbarHidden(false);
   }, [scroll.y, scroll.prevY]);
 
   // Remove focus from nav link when path changes.
   useEffect(() => {
-    setShowNav(false);
+    setMenuExpanded(false);
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur();
     }
   }, [pathname]);
 
-  const toggleNav = () => setShowNav((prevShowNav) => !prevShowNav);
+  const toggleNav = () => setMenuExpanded((prevMenuExpanded) => !prevMenuExpanded);
 
   return (
     <div className={`${styles.navbar} ${navbarHidden ? styles['navbar--hidden'] : ''}`}>
@@ -41,29 +45,39 @@ export default function Navbar(): JSX.Element {
           <Logo className={styles.nav__logo} />
           Trick Dog
         </NavLink>
-        <button
-          className={`${styles.nav__toggle} ${showNav ? styles.rotate : ''}`}
-          onClick={toggleNav}
-          aria-label={showNav ? 'Close navigation menu' : 'Open navigation menu'}
-          aria-expanded={showNav}
-          aria-controls='nav-menu'
-        >
-          {showNav ? (
-            <RiCloseLine aria-hidden='true' focusable='false' />
-          ) : (
-            <RiMenuLine aria-hidden='true' focusable='false' />
-          )}
-        </button>
+        {authed && (
+          <button
+            className={`${styles.nav__toggle} ${menuExpanded ? styles.rotate : ''}`}
+            onClick={toggleNav}
+            aria-label={menuExpanded ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={menuExpanded}
+            aria-controls='nav-menu'
+          >
+            {menuExpanded ? (
+              <RiCloseLine aria-hidden='true' focusable='false' />
+            ) : (
+              <RiMenuLine aria-hidden='true' focusable='false' />
+            )}
+          </button>
+        )}
         <div
           id='nav-menu'
-          className={`${styles.nav__menu} ${showNav ? '' : styles['nav__menu--collapsed']}`}
+          className={`${styles.nav__menu} ${authed ? styles['nav__menu--collapsible'] : ''} ${
+            authed && !menuExpanded ? styles['nav__menu--collapsed'] : ''
+          }`}
         >
-          <ul className={`${styles.nav__list} ${styles['nav__list--left']}`}>
-            <li className={styles.skew}>
-              <NavLink to='/' className={`${styles.nav__link} ${styles['nav__link--text']}`}>
-                <span className={styles.unskew}>Home</span>
-              </NavLink>
-            </li>
+          <ul
+            className={`${styles.nav__list} ${authed ? styles['nav__list--collapsible'] : ''} ${
+              authed ? styles['nav__list--left-collapsible'] : styles['nav__list--left']
+            }`}
+          >
+            {authed && (
+              <li className={styles.skew}>
+                <NavLink to='/' className={`${styles.nav__link} ${styles['nav__link--text']}`}>
+                  <span className={styles.unskew}>Home</span>
+                </NavLink>
+              </li>
+            )}
             {authed && (
               <li className={styles.skew}>
                 <NavLink to='/decks' className={`${styles.nav__link} ${styles['nav__link--text']}`}>
@@ -86,7 +100,11 @@ export default function Navbar(): JSX.Element {
               </li>
             )}
           </ul>
-          <ul className={`${styles.nav__list} ${styles['nav__list--right']}`}>
+          <ul
+            className={`${styles.nav__list} ${authed ? styles['nav__list--collapsible'] : ''} ${
+              authed ? styles['nav__list--right-collapsible'] : styles['nav__list--right']
+            }`}
+          >
             {authed && (
               <li>
                 <NavLink
@@ -107,17 +125,6 @@ export default function Navbar(): JSX.Element {
                   {(!showPicture || !userInfo || !userInfo.picture) && (
                     <BiUser aria-hidden='true' focusable='false' />
                   )}
-                </NavLink>
-              </li>
-            )}
-            {!authed && (
-              <li>
-                <NavLink
-                  to='/login'
-                  aria-label='Login'
-                  className={`${styles.nav__link} ${styles['nav__link--icon']}`}
-                >
-                  <BiUser aria-hidden='true' focusable='false' />
                 </NavLink>
               </li>
             )}

--- a/src/client/styles/_variables.scss
+++ b/src/client/styles/_variables.scss
@@ -38,7 +38,7 @@ $bg-primary--dark: $midnight;
 $bg-primary--light: $floral-white;
 $bg-secondary--dark: $black-russian;
 $bg-secondary--light: white;
-$shadow-primary--dark: hsl(215deg 42% 5% / 0.7);
+$shadow-primary--dark: hsl(215deg 42% 6% / 0.5);
 $shadow-primary--light: hsl(40deg 28% 75% / 0.5);
 $shadow-secondary--dark: hsl(221deg 63% 1% / 0.5);
 $shadow-secondary--light: hsl(0deg 0% 53% / 0.5);


### PR DESCRIPTION
# Description
Modified the style of the navbar component when the user is not authenticated. Expandable mobile navigation menu is only needed with authenticated navbar since everything fits on the navbar when the user is not authenticated. Removed navbar tests that are no longer applicable.
